### PR TITLE
Reorder order of env vars mentioned in the validation schemas

### DIFF
--- a/packages/live-market-data-service/src/utils/env.ts
+++ b/packages/live-market-data-service/src/utils/env.ts
@@ -3,11 +3,11 @@ import { parseEnv, z, port } from 'znv';
 export { parsedEnvPatchedWithExplicitTyping as env };
 
 const envShapeDef = {
+  NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
   PORT: port().default(3000),
   WS_PORT: port().default(3001),
   SYMBOL_MARKET_DATA_POLLING_INTERVAL_MS: z.number().default(2000),
   MOCK_SYMBOLS_MARKET_DATA: z.boolean().default(false),
-  NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
   ENABLE_NGROK_TUNNEL: z.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
 };

--- a/packages/main-service/src/utils/env.ts
+++ b/packages/main-service/src/utils/env.ts
@@ -3,14 +3,14 @@ import { parseEnv, z, port } from 'znv';
 export { parsedEnvPatchedWithExplicitTyping as env };
 
 const envShapeDef = {
+  NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
+  PORT: port().default(3000),
   INSTRUMENT_INFO_SERVICE_URL: z.string().url().min(1),
   LIVE_MARKET_PRICES_SERVICE_URL: z.string().url().min(1),
   LIVE_MARKET_PRICES_SERVICE_WS_URL: z.string().url().min(1),
-  DB_LOGGING: z.boolean().default(false),
   REDIS_CONNECTION_URL: z.string().url().min(1),
   POSTGRES_DB_CONNECTION_URL: z.string().url().min(1),
-  PORT: port().default(3000),
-  NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
+  DB_LOGGING: z.boolean().default(false),
   ENABLE_NGROK_TUNNEL: z.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
 };


### PR DESCRIPTION
Reorder order of env vars mentioned in the validation schemas so it appears that the more fundamental ones come before the less fundamental others.