### PR TITLE
Fix `main-service` `dockerfile`

### DIFF
--- a/packages/main-service/dockerfile
+++ b/packages/main-service/dockerfile
@@ -2,10 +2,8 @@ FROM node:22-alpine AS build
 WORKDIR /app
 RUN npm i --global pnpm
 COPY . .
-RUN \
-  pnpm i --no-frozen-lockfile --filter=main-service && \
-  cd ./packages/main-service && \
-  pnpm build-and-deploy
+RUN pnpm i --no-frozen-lockfile
+RUN cd ./packages/main-service && pnpm build-and-deploy
 
 FROM oven/bun:1.1.20-alpine
 WORKDIR /app


### PR DESCRIPTION
the part
```dockerfile
RUN cd ./packages/main-service && pnpm build-and-deploy
```
was crushing, having to do with some dependencies that cannot be found...

As much as I could see for now, what lead to this error going away was the removal of the `--filter=main-service` flag from the preceding pnpm installation command.