### PR TITLE
Make validation of boolean env vars not crush when provided as `""`

### DIFF
--- a/packages/instrument-info-service/src/utils/env.ts
+++ b/packages/instrument-info-service/src/utils/env.ts
@@ -3,10 +3,10 @@ import { parseEnv, z, port } from 'znv';
 export { env };
 
 const env = parseEnv(process.env, {
-  DB_LOGGING: z.boolean().default(false),
-  POSTGRES_DB_CONNECTION_URL: z.string().url().min(1),
-  PORT: port().default(3000),
   NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
-  ENABLE_NGROK_TUNNEL: z.boolean().default(false),
+  PORT: port().default(3000),
+  POSTGRES_DB_CONNECTION_URL: z.string().url().min(1),
+  DB_LOGGING: z.coerce.boolean().default(false),
+  ENABLE_NGROK_TUNNEL: z.coerce.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
 });

--- a/packages/live-market-data-service/src/utils/env.ts
+++ b/packages/live-market-data-service/src/utils/env.ts
@@ -6,9 +6,9 @@ const envShapeDef = {
   NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
   PORT: port().default(3000),
   WS_PORT: port().default(3001),
-  SYMBOL_MARKET_DATA_POLLING_INTERVAL_MS: z.number().default(2000),
-  MOCK_SYMBOLS_MARKET_DATA: z.boolean().default(false),
-  ENABLE_NGROK_TUNNEL: z.boolean().default(false),
+  SYMBOL_MARKET_DATA_POLLING_INTERVAL_MS: z.coerce.number().default(2000),
+  MOCK_SYMBOLS_MARKET_DATA: z.coerce.boolean().default(false),
+  ENABLE_NGROK_TUNNEL: z.coerce.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
 };
 

--- a/packages/main-service/src/utils/env.ts
+++ b/packages/main-service/src/utils/env.ts
@@ -10,8 +10,8 @@ const envShapeDef = {
   LIVE_MARKET_PRICES_SERVICE_WS_URL: z.string().url().min(1),
   REDIS_CONNECTION_URL: z.string().url().min(1),
   POSTGRES_DB_CONNECTION_URL: z.string().url().min(1),
-  DB_LOGGING: z.boolean().default(false),
-  ENABLE_NGROK_TUNNEL: z.boolean().default(false),
+  DB_LOGGING: z.coerce.boolean().default(false),
+  ENABLE_NGROK_TUNNEL: z.coerce.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
 };
 


### PR DESCRIPTION
Make validation of boolean env vars not crush when provided as \`""\`, and rather be translated into the default value.