### PR TITLE
Extra relevant changes for uniting `live-market-data-service`'s HTTP/WS double ports

### DIFF
--- a/packages/live-market-data-service/src/index.ts
+++ b/packages/live-market-data-service/src/index.ts
@@ -45,7 +45,6 @@ import { appApiRoutes } from './appApiRoutes/index.js';
   console.log(
     [
       `🚀 Server listening on port ${env.PORT}`,
-      `🚀 WS server listening to port ${env.WS_PORT}`,
       ngrokPublicUrl ? `, public URL: ${ngrokPublicUrl}` : '',
     ]
       .filter(Boolean)

--- a/packages/live-market-data-service/src/utils/env.ts
+++ b/packages/live-market-data-service/src/utils/env.ts
@@ -5,7 +5,6 @@ export { parsedEnvPatchedWithExplicitTyping as env };
 const envShapeDef = {
   NODE_ENV: z.enum(['test', 'development', 'production']).default('development'),
   PORT: port().default(3000),
-  WS_PORT: port().default(3001),
   SYMBOL_MARKET_DATA_POLLING_INTERVAL_MS: z.coerce.number().default(2000),
   MOCK_SYMBOLS_MARKET_DATA: z.coerce.boolean().default(false),
   ENABLE_NGROK_TUNNEL: z.coerce.boolean().default(false),


### PR DESCRIPTION
Extra changes to accompany what has been merged in https://github.com/shtaif/finstrument/pull/8.