### PR TITLE
Configure supertokens' session cookie to have `SameSite: Lax` if running on plain HTTP

### DIFF
--- a/packages/main-service/src/initSuperTokens/index.ts
+++ b/packages/main-service/src/initSuperTokens/index.ts
@@ -26,8 +26,16 @@ function initSuperTokens(params: {
     },
     recipeList: [
       SupertokensRecipeSession.init({
-        cookieSameSite: 'none',
         cookieDomain: params.sessionCookieDomain,
+        ...(new URL(params.apiDomain).protocol === 'https:'
+          ? {
+              cookieSameSite: 'none',
+              cookieSecure: true,
+            }
+          : {
+              cookieSameSite: 'lax',
+              cookieSecure: false,
+            }),
       }),
       SupertokensRecipeEmailPassword.init({
         override: {


### PR DESCRIPTION
Configure supertokens' session cookie to have `SameSite: Lax` conditionally if service was started over plain HTTP instead of HTTPS, such as during development.