### PR TITLE
Introduce `SYNC_SEQUELIZE_MODELS` env var

### DIFF
--- a/packages/main-service/spec/vitest.config.ts
+++ b/packages/main-service/spec/vitest.config.ts
@@ -29,6 +29,7 @@ export default {
       SUPERTOKENS_CORE_URL: 'http://supertokens-core-mock',
       LIVE_MARKET_PRICES_SERVICE_URL: 'http://localhost:4002',
       LIVE_MARKET_PRICES_SERVICE_WS_URL: 'ws://localhost:4002',
+      SYNC_SEQUELIZE_MODELS: 'false',
     },
   },
 } as const satisfies UserConfig;

--- a/packages/main-service/src/db/sequelize.ts
+++ b/packages/main-service/src/db/sequelize.ts
@@ -37,10 +37,12 @@ async function initDbSchema(): Promise<void> {
     `);
   }
 
-  await sequelize.sync({
-    alter: true,
-    force: false,
-  });
+  if (env.SYNC_SEQUELIZE_MODELS) {
+    await sequelize.sync({
+      alter: true,
+      force: false,
+    });
+  }
 
   if (pgSchemaName !== 'public') {
     /*

--- a/packages/main-service/src/utils/env.ts
+++ b/packages/main-service/src/utils/env.ts
@@ -17,6 +17,7 @@ const envShapeDef = {
   DB_LOGGING: z.coerce.boolean().default(false),
   ENABLE_NGROK_TUNNEL: z.coerce.boolean().default(false),
   NGROK_TUNNEL_AUTH_TOKEN: z.string().optional(),
+  SYNC_SEQUELIZE_MODELS: z.coerce.boolean().default(true),
 };
 
 /**


### PR DESCRIPTION
Introduce `SYNC_SEQUELIZE_MODELS` env var to control whether to execute `sequelize.sync(...)` during `main-service` start up.