### PR TITLE
Fix `live-market-data-service`'s live data iterables not being created as shared

### DIFF
--- a/packages/live-market-data-service/src/utils/observeMarketData/index.ts
+++ b/packages/live-market-data-service/src/utils/observeMarketData/index.ts
@@ -2,7 +2,7 @@ import { setImmediate } from 'node:timers/promises';
 import { uniq, flatten, pick } from 'lodash-es';
 import { pipe } from 'shared-utils';
 import { iterifiedUnwrapped } from 'iterified';
-import { asyncIterMap, itTakeFirst, myIterableCleanupPatcher } from 'iterable-operators';
+import { asyncIterMap, itShare, itTakeFirst, myIterableCleanupPatcher } from 'iterable-operators';
 import {
   yahooMarketPricesIterable,
   type SymbolPrices,
@@ -72,7 +72,8 @@ const baseSymbolPricesPoller = pipe(
     }
   }),
   asyncIterMap(currSymbolSet => pipe([...currSymbolSet], flatten, uniq)),
-  observedSymbolsIter => yahooMarketPricesIterable({ symbols: observedSymbolsIter })
+  observedSymbolsIter => yahooMarketPricesIterable({ symbols: observedSymbolsIter }),
+  itShare()
 );
 
 async function marketDataPrimeFasterInit(): Promise<void> {


### PR DESCRIPTION
…d as shared