### PR TITLE
`useAsyncIterable` fix late completion of recently unsubscribed iterable possibly overriding state unexpectedly

### DIFF
--- a/packages/react-async-iterable/useAsyncIterable/index.ts
+++ b/packages/react-async-iterable/useAsyncIterable/index.ts
@@ -89,13 +89,15 @@ function useAsyncIterable<TValue, TInitValue = undefined>(
               rerender();
             }
           }
-          stateRef.current = {
-            value: stateRef.current.value,
-            pendingFirst: false,
-            done: true,
-            error: undefined,
-          };
-          rerender();
+          if (!iteratorClosedAbruptly) {
+            stateRef.current = {
+              value: stateRef.current.value,
+              pendingFirst: false,
+              done: true,
+              error: undefined,
+            };
+            rerender();
+          }
         } catch (err) {
           if (!iteratorClosedAbruptly) {
             stateRef.current = {


### PR DESCRIPTION
`useAsyncIterable` fix late completion of recently unsubscribed iterable possibly overriding current state unexpectedly with expired data that falsely indicates a completion, all whilst we're tracking iterations of the current (*next*) active iterable.