### PR TITLE
Adapt `main-service`'s testing environment to have its Postgres and Redis configurable

### DIFF
--- a/packages/main-service/README.md
+++ b/packages/main-service/README.md
@@ -1,0 +1,33 @@
+## Setup for quick start:
+
+### For running the service:
+
+Create a `.env.local` file and edit its env vars according to this sample:
+
+```sh
+NODE_ENV=development
+PORT=3001
+APP_PUBLIC_URL=http://localhost:3001
+AUTH_FRONTEND_ORIGIN_URL=http://localhost:5173
+AUTH_SESSION_COOKIE_DOMAIN=.localhost
+LIVE_MARKET_PRICES_SERVICE_URL=http://localhost:3002
+LIVE_MARKET_PRICES_SERVICE_WS_URL=ws://localhost:3002
+INSTRUMENT_INFO_SERVICE_URL=http://localhost:3004
+SUPERTOKENS_CORE_URL=http://localhost:3567
+REDIS_CONNECTION_URL=redis://127.0.0.1:6379
+POSTGRES_DB_CONNECTION_URL="postgresql://finance_data_project_user:123456789@127.0.0.1:5432/finance_data_project?schema=public"
+ENABLE_NGROK_TUNNEL=false
+NGROK_TUNNEL_AUTH_TOKEN=
+SYNC_SEQUELIZE_MODELS=false
+DB_LOGGING=false
+```
+
+### For running tests:
+
+Create a `.env.tests.local` file and edit its env vars according to this sample:
+
+```sh
+REDIS_CONNECTION_URL=redis://127.0.0.1:6379
+POSTGRES_DB_CONNECTION_URL="postgresql://finance_data_project_user:123456789@127.0.0.1:5432/finance_data_project?schema=main_service_testing"
+DB_LOGGING=false
+```

--- a/packages/main-service/spec/vitest.config.ts
+++ b/packages/main-service/spec/vitest.config.ts
@@ -1,4 +1,7 @@
+import { loadEnvFile } from 'node:process';
 import { type UserConfig } from 'vitest/config';
+
+loadEnvFile(`${import.meta.dirname}/../.env.tests.local`);
 
 export default {
   test: {
@@ -20,9 +23,6 @@ export default {
       PORT: '4001',
       APP_PUBLIC_URL: 'http://localhost:4001',
       ENABLE_NGROK_TUNNEL: 'false',
-      REDIS_CONNECTION_URL: 'redis://127.0.0.1:6379',
-      POSTGRES_DB_CONNECTION_URL:
-        'postgresql://finance_data_project_user:123456789@127.0.0.1:5432/finance_data_project?schema=main_service_testing',
       INSTRUMENT_INFO_SERVICE_URL: 'http://mock-instrument-info-service',
       AUTH_FRONTEND_ORIGIN_URL: 'http://auth-frontend-origin-mock',
       AUTH_SESSION_COOKIE_DOMAIN: 'auth-session-cookie-domain-mock',


### PR DESCRIPTION
Adapt `main-service`'s testing environment to have its Postgres and Redis connection URLs user-configurable instead of fixed via a `.env.tests.local` file