### PR TITLE
`ssl` option to `true` on `main-service` Sequelize config

### DIFF
--- a/packages/main-service/src/db/sequelize.ts
+++ b/packages/main-service/src/db/sequelize.ts
@@ -17,6 +17,7 @@ const sequelize = new Sequelize(env.POSTGRES_DB_CONNECTION_URL, {
   logging: env.DB_LOGGING ? console.log : undefined,
   schema: pgSchemaName,
   dialect: 'postgres',
+  ssl: true,
   pool: {},
   models: [
     UserModel,


### PR DESCRIPTION
I don't remember the story with this one, only that for some reason not including a `?ssl=true` in the end of the DB url for `main-service`'s config on render.com was resulting in an issue in connecting to render.com's PG DB. So this attempts to mitigate this internally at least, so there wasn't a need to obscurely remember to put the `?ssl=true` param at the end of `main-service`'s DB url var explicitly...